### PR TITLE
docs: write a real README — who I am, for anyone visiting from GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,70 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Najmu Syathir
 
-## Getting Started
+Full-Stack Engineer based in Kuala Lumpur, Malaysia.
 
-First, run the development server:
+This repository is the source for my personal site and portfolio. This README isn't about the codebase — it's about me, for anyone who lands here from GitHub and wants the short version.
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
-```
+## Currently
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Full-Stack Engineer at **myFirst Tech Sdn Bhd** (Mar 2025–present). I work across the stack — front end, back end, and the infrastructure in between:
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+- Maintaining and supporting the company's internal web portal
+- Designed and built the base architecture for its next-generation rebuild ("Portal 3.0")
+- Helped design the customer journey for a subscription-based platform
+- Built a real-time, AI-integrated customer-support chat
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+Day-to-day stack there: Next.js, TypeScript, Go, PostgreSQL, Firestore, Realtime Database, Stripe, Airwallex, webhook-driven integrations.
 
-## Learn More
+## Background
 
-To learn more about Next.js, take a look at the following resources:
+I didn't start out in software. My first real interest was PC building — putting together workstations, caring about how a setup felt to work in. That curiosity about "what makes a good working environment" eventually pulled me toward computer science: I picked up Python in 2019, and by 2021 had committed to it fully, switching away from an earlier plan in medicine/health sciences to pursue a Computer Science degree instead.
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+**Career path:**
+- **Full-Stack Engineer**, myFirst Tech Sdn Bhd — Mar 2025–present
+- **Junior Software Developer & Operations (FE)**, Guard Genius Sdn Bhd — Aug 2024–Mar 2025 (Vue.js, Tailwind CSS, Flask, MySQL, Figma, Sentry)
+- **Software Developer Intern**, AQ Wise Sdn Bhd — Mar–Jun 2024 (Flutter, Laravel)
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+**Education:**
+- Bachelor of Computer Science (Hons.), Universiti Teknologi MARA, Melaka — 2023
+- Diploma in Applied Science, Universiti Teknologi MARA, Perlis — 2021
 
-## Deploy on Vercel
+## What I work with
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+**Languages & frameworks:** TypeScript, JavaScript, Go, Python, PHP · React, Next.js, Vue.js, Tailwind CSS
+**Backend & data:** Node.js, FastAPI, Flask, Laravel · PostgreSQL, MySQL, Prisma, Firestore, Realtime Database
+**Infra:** Docker, Git, Linux server administration, Cloudflare Tunnels
+**Payments:** Stripe, Airwallex
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+## Self-hosted, on my own server
+
+Outside of client and employer work, I run a small ecosystem of self-hosted projects on infrastructure I administer myself — not just deployed, but actually operated: process supervision, monitoring, and uptime are things I manage directly, not hand off to a platform.
+
+- **personal-dashboard** — an AI-connected personal life assistant: finances, event scheduling, meetings, career, and day-to-day tasks in one place
+- **acadeon-cli** — a browser-based terminal with TOTP authentication
+- **acadeon-pulse** — an uptime monitor with escalating push alerts
+- **ssh-web-server** — a browser-based SSH client
+- **ai_hub_bridge** — an async job queue bridging AI tooling to web and messaging clients in real time
+
+## Earlier / client work
+
+- **CPU–Motherboard Compatibility Checker** — a browser extension verifying part compatibility on e-commerce cart pages. Awarded *Best Industrial Panel Final Year Project* (2024).
+- **PetCare Clinic System** — grooming and vet-booking platform (Laravel)
+- **MNS Tech Store** — e-commerce platform for PC parts and accessories (Laravel)
+- **Astral Apparel** — online store for modest fashion
+- **Bakers Heist** — e-commerce storefront for a bakery
+
+## Outside of work
+
+Code, Coffee & Chill — I do my best work away from a desk: café-hunting for a good spot and a quiet corner is genuinely part of how I stay focused. Also still into PC building, where this all started.
+
+## Find me
+
+- GitHub: [@najmusyathir](https://github.com/najmusyathir)
+- LinkedIn: [najmusyathir](https://www.linkedin.com/in/najmusyathir/)
+- Portfolio: [portfolio-dev.najmusyathir.dev](https://portfolio-dev.najmusyathir.dev)
+
+---
+
+### About this repo
+
+Next.js 16 + TypeScript + Tailwind CSS 4 portfolio site. Design system: single token-driven component set with a dark theme ("Charcoal & Oud") as the default and a light theme toggle, built from scratch with the original portfolio's content and character as the reference point rather than a template.


### PR DESCRIPTION
Replaces the default create-next-app boilerplate with an actual profile: current role, background, stack, self-hosted projects, and earlier work.